### PR TITLE
Fix main script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-onesignal",
   "version": "0.2.0",
   "description": "Node wrapper for the One Signal API",
-  "main": "./dist/onesignal.js",
+  "main": "./dist/client.js",
   "scripts": {
     "build": "./node_modules/.bin/babel -q -L -D ./lib/ --out-dir ./dist/",
     "prepublish": "npm run clean && npm run build",


### PR DESCRIPTION
Node couldn't find the main script of the package since the name was
wrong in package.json.
